### PR TITLE
fix: Insert text at beginning

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -148,6 +148,10 @@
     "message": "An bestehenden Inhalt anhängen",
     "description": "Option: Vorlageninhalt an bestehende E-Mail anhängen"
   },
+  "optionsInsertModePrepend": {
+    "message": "Am Anfang einfügen",
+    "description": "Option: Vorlageninhalt am Anfang der bestehenden E-Mail einfügen"
+  },
   "optionsInsertModeReplace": {
     "message": "Bestehenden Inhalt ersetzen",
     "description": "Option: bestehenden E-Mail-Inhalt durch Vorlage ersetzen"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -148,6 +148,10 @@
     "message": "Append to existing content",
     "description": "Option to append template body to existing email body"
   },
+  "optionsInsertModePrepend": {
+    "message": "Insert at beginning",
+    "description": "Option to insert template body at the beginning of existing email body"
+  },
   "optionsInsertModeReplace": {
     "message": "Replace existing content",
     "description": "Option to replace existing email body with template body"

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -148,6 +148,10 @@
     "message": "Agregar al contenido existente",
     "description": "Option to append template body to existing email body"
   },
+  "optionsInsertModePrepend": {
+    "message": "Insertar al principio",
+    "description": "Option to insert template body at the beginning of existing email body"
+  },
   "optionsInsertModeReplace": {
     "message": "Reemplazar contenido existente",
     "description": "Option to replace existing email body with template body"

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -148,6 +148,10 @@
     "message": "Ajouter au contenu existant",
     "description": "Option to append template body to existing email body"
   },
+  "optionsInsertModePrepend": {
+    "message": "Insérer au début",
+    "description": "Option to insert template body at the beginning of existing email body"
+  },
   "optionsInsertModeReplace": {
     "message": "Remplacer le contenu existant",
     "description": "Option to replace existing email body with template body"

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -148,6 +148,10 @@
     "message": "Accoda al contenuto esistente",
     "description": "Option to append template body to existing email body"
   },
+  "optionsInsertModePrepend": {
+    "message": "Inserisci all'inizio",
+    "description": "Option to insert template body at the beginning of existing email body"
+  },
   "optionsInsertModeReplace": {
     "message": "Sostituisci contenuto esistente",
     "description": "Option to replace existing email body with template body"

--- a/_locales/nl/messages.json
+++ b/_locales/nl/messages.json
@@ -148,6 +148,10 @@
     "message": "Toevoegen aan bestaande inhoud",
     "description": "Option to append template body to existing email body"
   },
+  "optionsInsertModePrepend": {
+    "message": "Vooraan invoegen",
+    "description": "Option to insert template body at the beginning of existing email body"
+  },
   "optionsInsertModeReplace": {
     "message": "Bestaande inhoud vervangen",
     "description": "Option to replace existing email body with template body"

--- a/_locales/pt/messages.json
+++ b/_locales/pt/messages.json
@@ -148,6 +148,10 @@
     "message": "Acrescentar ao conteúdo existente",
     "description": "Option to append template body to existing email body"
   },
+  "optionsInsertModePrepend": {
+    "message": "Inserir no início",
+    "description": "Option to insert template body at the beginning of existing email body"
+  },
   "optionsInsertModeReplace": {
     "message": "Substituir conteúdo existente",
     "description": "Option to replace existing email body with template body"

--- a/modules/template-insert.js
+++ b/modules/template-insert.js
@@ -170,6 +170,9 @@ export async function insertTemplateIntoTab(tabId, template) {
     const body = await replaceVariables(resolvedBody, tabId);
     if (mode === "replace") {
       details.body = body;
+    } else if (mode === "prepend") {
+      const existing = await messenger.compose.getComposeDetails(tabId);
+      details.body = body + (existing.body || "");
     } else {
       const existing = await messenger.compose.getComposeDetails(tabId);
       details.body = (existing.body || "") + body;

--- a/options/options.html
+++ b/options/options.html
@@ -75,6 +75,7 @@
         <label data-i18n="optionsLabelInsertMode"></label>
         <select id="editor-insert-mode">
           <option value="append" data-i18n="optionsInsertModeAppend"></option>
+          <option value="prepend" data-i18n="optionsInsertModePrepend"></option>
           <option value="replace" data-i18n="optionsInsertModeReplace"></option>
         </select>
 


### PR DESCRIPTION
## Summary

Adds an option to insert email body text at the beginning of the email, complementing the existing append and replace modes.

## Changes

- Added insert-at-beginning mode alongside existing append/replace options
- Updated insertion logic in template-insert.js to support three modes
- Added i18n strings for all 7 supported languages

## Testing

All 26 existing tests pass. JSON locale files validated.

Fixes JuliaKalder/TemplateWing#24