### PR TITLE
fix: v2.1 improve recipient and template validation

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -11,7 +11,6 @@
     "message": "Vorlagen",
     "description": "Tooltip für den Compose-Action-Button"
   },
-
   "menuInsertTemplate": {
     "message": "Vorlage einfügen",
     "description": "Kontextmenü-Eintrag im Verfassen-Fenster"
@@ -24,7 +23,6 @@
     "message": "Als Vorlage speichern",
     "description": "Kontextmenü-Eintrag in der Nachrichtenliste"
   },
-
   "popupTitle": {
     "message": "Vorlagen",
     "description": "Popup-Überschrift"
@@ -41,7 +39,6 @@
     "message": "Vorlagen verwalten…",
     "description": "Button zum Öffnen der Einstellungsseite"
   },
-
   "optionsTitle": {
     "message": "TemplateWing — Vorlagen verwalten",
     "description": "Überschrift der Einstellungsseite"
@@ -75,8 +72,8 @@
     "description": "Label für das Textfeld"
   },
   "optionsBack": {
-    "message": "\u2190 Zur\u00fcck",
-    "description": "Zur\u00fcck-Button zur Vorlagenliste"
+    "message": "← Zurück",
+    "description": "Zurück-Button zur Vorlagenliste"
   },
   "optionsSave": {
     "message": "Speichern",
@@ -104,12 +101,10 @@
       }
     }
   },
-
   "optionsSaveError": {
     "message": "Vorlage konnte nicht gespeichert werden. Möglicherweise ist der Speicher voll — versuche, Anhänge zu verkleinern oder alte Vorlagen zu löschen.",
     "description": "Fehlermeldung wenn das Speichern fehlschlägt"
   },
-
   "optionsLabelAttachments": {
     "message": "Anhänge",
     "description": "Label für den Anhänge-Bereich im Editor"
@@ -156,7 +151,6 @@
     "message": "Bestehenden Inhalt ersetzen",
     "description": "Option: bestehenden E-Mail-Inhalt durch Vorlage ersetzen"
   },
-
   "popupAttachmentCount": {
     "message": "$COUNT$ Anhang/Anhänge",
     "description": "Anzahl der Anhänge im Popup",
@@ -167,7 +161,6 @@
       }
     }
   },
-
   "optionsLabelCategory": {
     "message": "Kategorie (optional)",
     "description": "Label für Kategoriefeld"
@@ -184,7 +177,6 @@
     "message": "Alle",
     "description": "Option zum Anzeigen aller Kategorien im Popup-Filter"
   },
-
   "optionsLabelTo": {
     "message": "An (Empfänger)",
     "description": "Label für An-Feld"
@@ -201,7 +193,6 @@
     "message": "Mehrere Empfänger durch Komma trennen. Beispiel: max@beispiel.de, Maria Müller <maria@beispiel.de>",
     "description": "Hilfetext für Empfängerfelder"
   },
-
   "optionsLabelVariables": {
     "message": "Verfügbare Variablen",
     "description": "Label für den Variablen-Hilfebereich"
@@ -222,7 +213,6 @@
     "message": "{SENDER_EMAIL} — Ihre E-Mail",
     "description": "Beschreibt SENDER_EMAIL-Variable"
   },
-
   "optionsUsageCount": {
     "message": "$COUNT$-mal verwendet",
     "description": "Nutzungszähler auf der Vorlagenkarte",
@@ -259,7 +249,6 @@
     "message": "Ungültige Datei. Bitte eine gültige TemplateWing-JSON-Exportdatei wählen.",
     "description": "Fehlermeldung bei ungültiger Importdatei"
   },
-
   "optionsLabelAccounts": {
     "message": "Konten (optional)",
     "description": "Label für die Konten-/Identitätsauswahl"
@@ -272,7 +261,6 @@
     "message": "Alle Konten",
     "description": "Option um Vorlage für alle Konten anzuzeigen"
   },
-
   "optionsLabelNestedTemplates": {
     "message": "Verschachtelte Vorlagen",
     "description": "Label for nested template help section"
@@ -289,7 +277,6 @@
     "message": "Vorlage zum Verschachteln auswählen…",
     "description": "Placeholder for nested template dropdown"
   },
-
   "importDialogTitle": {
     "message": "Import-Zusammenfassung",
     "description": "Title of the import confirmation dialog"
@@ -302,21 +289,30 @@
     "message": "$COUNT$ Vorlage(n) in Datei gefunden",
     "description": "Total templates found in the import file",
     "placeholders": {
-      "count": { "content": "$1", "example": "5" }
+      "count": {
+        "content": "$1",
+        "example": "5"
+      }
     }
   },
   "importDialogInvalid": {
     "message": "$COUNT$ ungültig (werden übersprungen)",
     "description": "Number of invalid entries in the import file",
     "placeholders": {
-      "count": { "content": "$1", "example": "1" }
+      "count": {
+        "content": "$1",
+        "example": "1"
+      }
     }
   },
   "importDialogDuplicates": {
     "message": "$COUNT$ mit bereits vorhandenen Namen",
     "description": "Number of templates with names that already exist",
     "placeholders": {
-      "count": { "content": "$1", "example": "2" }
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
     }
   },
   "importModeAppend": {
@@ -355,12 +351,20 @@
     "message": "$ADDED$ hinzugefügt, $SKIPPED$ übersprungen, $REPLACED$ ersetzt.",
     "description": "Result message after import completes",
     "placeholders": {
-      "added": { "content": "$1", "example": "3" },
-      "skipped": { "content": "$2", "example": "1" },
-      "replaced": { "content": "$3", "example": "0" }
+      "added": {
+        "content": "$1",
+        "example": "3"
+      },
+      "skipped": {
+        "content": "$2",
+        "example": "1"
+      },
+      "replaced": {
+        "content": "$3",
+        "example": "0"
+      }
     }
   },
-
   "validationNameRequired": {
     "message": "Vorlagenname ist erforderlich.",
     "description": "Error when template name is empty"
@@ -369,10 +373,12 @@
     "message": "Ungültige(r) Empfänger: $LIST$",
     "description": "Error when recipient email format is invalid",
     "placeholders": {
-      "list": { "content": "$1", "example": "bad-email, another" }
+      "list": {
+        "content": "$1",
+        "example": "bad-email, another"
+      }
     }
   },
-
   "attachmentSizeWarning": {
     "message": "Große Datei",
     "description": "Short warning shown next to a large attachment"
@@ -381,17 +387,22 @@
     "message": "Gesamtgröße der Anhänge ($SIZE$) ist groß. Dies kann den Speicherverbrauch erheblich erhöhen.",
     "description": "Warning when total attachment size exceeds threshold",
     "placeholders": {
-      "size": { "content": "$1", "example": "12.5 MB" }
+      "size": {
+        "content": "$1",
+        "example": "12.5 MB"
+      }
     }
   },
   "attachmentReadError": {
     "message": "Datei \"$NAME$\" konnte nicht gelesen werden.",
     "description": "Error when a file cannot be read during attachment",
     "placeholders": {
-      "name": { "content": "$1", "example": "document.pdf" }
+      "name": {
+        "content": "$1",
+        "example": "document.pdf"
+      }
     }
   },
-
   "optionsVariableDatetime": {
     "message": "{DATETIME} — Aktuelles Datum und Uhrzeit",
     "description": "Describes DATETIME variable"
@@ -437,5 +448,9 @@
   "notificationInsertFailedGeneric": {
     "message": "Die Vorlage konnte nicht eingefügt werden. Details finden Sie in der Fehlerkonsole.",
     "description": "Notification body for a generic template insertion failure"
+  },
+  "validationBodyEmptyReplace": {
+    "message": "Warnung: Der Textkörper ist leer. Der Ersetzen-Modus entfernt den ursprünglichen Nachrichteninhalt.",
+    "description": "Warning shown when body is empty/whitespace in replace insert mode"
   }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -11,7 +11,6 @@
     "message": "Templates",
     "description": "Tooltip for the compose action button"
   },
-
   "menuInsertTemplate": {
     "message": "Insert Template",
     "description": "Context menu root item in compose body"
@@ -24,7 +23,6 @@
     "message": "Save as Template",
     "description": "Context menu item on a message in the message list"
   },
-
   "popupTitle": {
     "message": "Templates",
     "description": "Popup heading"
@@ -41,7 +39,6 @@
     "message": "Manage Templates…",
     "description": "Button to open options page"
   },
-
   "optionsTitle": {
     "message": "TemplateWing — Manage Templates",
     "description": "Options page heading"
@@ -75,7 +72,7 @@
     "description": "Label for body textarea"
   },
   "optionsBack": {
-    "message": "\u2190 Back",
+    "message": "← Back",
     "description": "Back button to return to template list"
   },
   "optionsSave": {
@@ -104,12 +101,10 @@
       }
     }
   },
-
   "optionsSaveError": {
     "message": "Could not save template. Storage may be full — try reducing attachment sizes or deleting old templates.",
     "description": "Error message when saving fails"
   },
-
   "optionsLabelAttachments": {
     "message": "Attachments",
     "description": "Label for attachments section in editor"
@@ -156,7 +151,6 @@
     "message": "Replace existing content",
     "description": "Option to replace existing email body with template body"
   },
-
   "popupAttachmentCount": {
     "message": "$COUNT$ attachment(s)",
     "description": "Attachment count shown in popup",
@@ -167,7 +161,6 @@
       }
     }
   },
-
   "optionsLabelCategory": {
     "message": "Category (optional)",
     "description": "Label for category input"
@@ -184,7 +177,6 @@
     "message": "All",
     "description": "Option to show all categories in popup filter"
   },
-
   "optionsLabelTo": {
     "message": "To (Recipients)",
     "description": "Label for To field"
@@ -201,7 +193,6 @@
     "message": "Separate multiple recipients with commas. Example: john@example.com, Jane Doe <jane@example.com>",
     "description": "Help text for recipient fields"
   },
-
   "optionsLabelVariables": {
     "message": "Available Variables",
     "description": "Label for variables help section"
@@ -222,7 +213,6 @@
     "message": "{SENDER_EMAIL} — Your email",
     "description": "Describes SENDER_EMAIL variable"
   },
-
   "optionsUsageCount": {
     "message": "Used $COUNT$ time(s)",
     "description": "Usage count shown on template card",
@@ -259,7 +249,6 @@
     "message": "Invalid file. Please select a valid TemplateWing JSON export.",
     "description": "Error message when an invalid file is imported"
   },
-
   "optionsLabelAccounts": {
     "message": "Accounts (optional)",
     "description": "Label for accounts/identities selection"
@@ -272,7 +261,6 @@
     "message": "All Accounts",
     "description": "Option to show template for all accounts"
   },
-
   "optionsLabelNestedTemplates": {
     "message": "Nested Templates",
     "description": "Label for nested template help section"
@@ -289,7 +277,6 @@
     "message": "Select a template to nest…",
     "description": "Placeholder for nested template dropdown"
   },
-
   "importDialogTitle": {
     "message": "Import Summary",
     "description": "Title of the import confirmation dialog"
@@ -302,21 +289,30 @@
     "message": "$COUNT$ template(s) found in file",
     "description": "Total templates found in the import file",
     "placeholders": {
-      "count": { "content": "$1", "example": "5" }
+      "count": {
+        "content": "$1",
+        "example": "5"
+      }
     }
   },
   "importDialogInvalid": {
     "message": "$COUNT$ invalid (will be skipped)",
     "description": "Number of invalid entries in the import file",
     "placeholders": {
-      "count": { "content": "$1", "example": "1" }
+      "count": {
+        "content": "$1",
+        "example": "1"
+      }
     }
   },
   "importDialogDuplicates": {
     "message": "$COUNT$ with existing name(s)",
     "description": "Number of templates with names that already exist",
     "placeholders": {
-      "count": { "content": "$1", "example": "2" }
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
     }
   },
   "importModeAppend": {
@@ -355,12 +351,20 @@
     "message": "$ADDED$ added, $SKIPPED$ skipped, $REPLACED$ replaced.",
     "description": "Result message after import completes",
     "placeholders": {
-      "added": { "content": "$1", "example": "3" },
-      "skipped": { "content": "$2", "example": "1" },
-      "replaced": { "content": "$3", "example": "0" }
+      "added": {
+        "content": "$1",
+        "example": "3"
+      },
+      "skipped": {
+        "content": "$2",
+        "example": "1"
+      },
+      "replaced": {
+        "content": "$3",
+        "example": "0"
+      }
     }
   },
-
   "validationNameRequired": {
     "message": "Template name is required.",
     "description": "Error when template name is empty"
@@ -369,10 +373,12 @@
     "message": "Invalid recipient(s): $LIST$",
     "description": "Error when recipient email format is invalid",
     "placeholders": {
-      "list": { "content": "$1", "example": "bad-email, another" }
+      "list": {
+        "content": "$1",
+        "example": "bad-email, another"
+      }
     }
   },
-
   "attachmentSizeWarning": {
     "message": "Large file",
     "description": "Short warning shown next to a large attachment"
@@ -381,17 +387,22 @@
     "message": "Total attachment size ($SIZE$) is large. This may increase storage usage significantly.",
     "description": "Warning when total attachment size exceeds threshold",
     "placeholders": {
-      "size": { "content": "$1", "example": "12.5 MB" }
+      "size": {
+        "content": "$1",
+        "example": "12.5 MB"
+      }
     }
   },
   "attachmentReadError": {
     "message": "Could not read file \"$NAME$\".",
     "description": "Error when a file cannot be read during attachment",
     "placeholders": {
-      "name": { "content": "$1", "example": "document.pdf" }
+      "name": {
+        "content": "$1",
+        "example": "document.pdf"
+      }
     }
   },
-
   "optionsVariableDatetime": {
     "message": "{DATETIME} — Current date and time",
     "description": "Describes DATETIME variable"
@@ -437,5 +448,9 @@
   "notificationInsertFailedGeneric": {
     "message": "The template could not be inserted. See the error console for details.",
     "description": "Notification body for a generic template insertion failure"
+  },
+  "validationBodyEmptyReplace": {
+    "message": "Warning: Body is empty. The replace mode will remove the original message content.",
+    "description": "Warning shown when body is empty/whitespace in replace insert mode"
   }
 }

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -11,7 +11,6 @@
     "message": "Plantillas",
     "description": "Tooltip for the compose action button"
   },
-
   "menuInsertTemplate": {
     "message": "Insertar plantilla",
     "description": "Context menu root item in compose body"
@@ -24,7 +23,6 @@
     "message": "Guardar como plantilla",
     "description": "Context menu item on a message in the message list"
   },
-
   "popupTitle": {
     "message": "Plantillas",
     "description": "Popup heading"
@@ -41,7 +39,6 @@
     "message": "Gestionar plantillas…",
     "description": "Button to open options page"
   },
-
   "optionsTitle": {
     "message": "TemplateWing — Gestionar plantillas",
     "description": "Options page heading"
@@ -75,7 +72,7 @@
     "description": "Label for body textarea"
   },
   "optionsBack": {
-    "message": "\u2190 Volver",
+    "message": "← Volver",
     "description": "Back button to return to template list"
   },
   "optionsSave": {
@@ -104,12 +101,10 @@
       }
     }
   },
-
   "optionsSaveError": {
     "message": "No se pudo guardar la plantilla. El almacenamiento puede estar lleno — intenta reducir el tamaño de los archivos adjuntos o eliminar plantillas antiguas.",
     "description": "Error message when saving fails"
   },
-
   "optionsLabelAttachments": {
     "message": "Archivos adjuntos",
     "description": "Label for attachments section in editor"
@@ -156,7 +151,6 @@
     "message": "Reemplazar contenido existente",
     "description": "Option to replace existing email body with template body"
   },
-
   "popupAttachmentCount": {
     "message": "$COUNT$ archivo(s) adjunto(s)",
     "description": "Attachment count shown in popup",
@@ -167,7 +161,6 @@
       }
     }
   },
-
   "optionsLabelCategory": {
     "message": "Categoría (opcional)",
     "description": "Label for category input"
@@ -184,7 +177,6 @@
     "message": "Todos",
     "description": "Option to show all categories in popup filter"
   },
-
   "optionsLabelTo": {
     "message": "Para (Destinatarios)",
     "description": "Label for To field"
@@ -201,7 +193,6 @@
     "message": "Separa varios destinatarios con comas. Ejemplo: juan@ejemplo.com, Juan Pérez <juan@ejemplo.com>",
     "description": "Help text for recipient fields"
   },
-
   "optionsLabelVariables": {
     "message": "Variables disponibles",
     "description": "Label for variables help section"
@@ -222,7 +213,6 @@
     "message": "{SENDER_EMAIL} — Tu correo electrónico",
     "description": "Describes SENDER_EMAIL variable"
   },
-
   "optionsUsageCount": {
     "message": "Usado $COUNT$ vez/veces",
     "description": "Usage count shown on template card",
@@ -259,7 +249,6 @@
     "message": "Archivo inválido. Por favor selecciona un archivo JSON de TemplateWing válido.",
     "description": "Error message when an invalid file is imported"
   },
-
   "optionsLabelAccounts": {
     "message": "Cuentas (opcional)",
     "description": "Label for accounts/identities selection"
@@ -272,7 +261,6 @@
     "message": "Todas las cuentas",
     "description": "Option to show template for all accounts"
   },
-
   "optionsLabelNestedTemplates": {
     "message": "Plantillas anidadas",
     "description": "Label for nested template help section"
@@ -289,7 +277,6 @@
     "message": "Selecciona una plantilla para anidar…",
     "description": "Placeholder for nested template dropdown"
   },
-
   "importDialogTitle": {
     "message": "Resumen de importación",
     "description": "Title of the import confirmation dialog"
@@ -302,21 +289,30 @@
     "message": "$COUNT$ plantilla(s) encontrada(s) en el archivo",
     "description": "Total templates found in the import file",
     "placeholders": {
-      "count": { "content": "$1", "example": "5" }
+      "count": {
+        "content": "$1",
+        "example": "5"
+      }
     }
   },
   "importDialogInvalid": {
     "message": "$COUNT$ inválida(s) (se omitirán)",
     "description": "Number of invalid entries in the import file",
     "placeholders": {
-      "count": { "content": "$1", "example": "1" }
+      "count": {
+        "content": "$1",
+        "example": "1"
+      }
     }
   },
   "importDialogDuplicates": {
     "message": "$COUNT$ con nombres existentes",
     "description": "Number of templates with names that already exist",
     "placeholders": {
-      "count": { "content": "$1", "example": "2" }
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
     }
   },
   "importModeAppend": {
@@ -355,12 +351,20 @@
     "message": "$ADDED$ agregada(s), $SKIPPED$ omitida(s), $REPLACED$ reemplazada(s).",
     "description": "Result message after import completes",
     "placeholders": {
-      "added": { "content": "$1", "example": "3" },
-      "skipped": { "content": "$2", "example": "1" },
-      "replaced": { "content": "$3", "example": "0" }
+      "added": {
+        "content": "$1",
+        "example": "3"
+      },
+      "skipped": {
+        "content": "$2",
+        "example": "1"
+      },
+      "replaced": {
+        "content": "$3",
+        "example": "0"
+      }
     }
   },
-
   "validationNameRequired": {
     "message": "El nombre de la plantilla es obligatorio.",
     "description": "Error when template name is empty"
@@ -369,10 +373,12 @@
     "message": "Destinatario(s) inválido(s): $LIST$",
     "description": "Error when recipient email format is invalid",
     "placeholders": {
-      "list": { "content": "$1", "example": "bad-email, another" }
+      "list": {
+        "content": "$1",
+        "example": "bad-email, another"
+      }
     }
   },
-
   "attachmentSizeWarning": {
     "message": "Archivo grande",
     "description": "Short warning shown next to a large attachment"
@@ -381,17 +387,22 @@
     "message": "El tamaño total de los archivos adjuntos ($SIZE$) es grande. Esto puede aumentar significativamente el uso de almacenamiento.",
     "description": "Warning when total attachment size exceeds threshold",
     "placeholders": {
-      "size": { "content": "$1", "example": "12.5 MB" }
+      "size": {
+        "content": "$1",
+        "example": "12.5 MB"
+      }
     }
   },
   "attachmentReadError": {
     "message": "No se pudo leer el archivo «$NAME$».",
     "description": "Error when a file cannot be read during attachment",
     "placeholders": {
-      "name": { "content": "$1", "example": "document.pdf" }
+      "name": {
+        "content": "$1",
+        "example": "document.pdf"
+      }
     }
   },
-
   "optionsVariableDatetime": {
     "message": "{DATETIME} — Fecha y hora actual",
     "description": "Describes DATETIME variable"
@@ -437,5 +448,9 @@
   "notificationInsertFailedGeneric": {
     "message": "No se pudo insertar la plantilla. Consulta la consola de errores para más detalles.",
     "description": "Notification body for a generic template insertion failure"
+  },
+  "validationBodyEmptyReplace": {
+    "message": "Advertencia: el cuerpo está vacío. El modo reemplazar eliminará el contenido del mensaje original.",
+    "description": "Warning shown when body is empty/whitespace in replace insert mode"
   }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -11,7 +11,6 @@
     "message": "Modèles",
     "description": "Tooltip for the compose action button"
   },
-
   "menuInsertTemplate": {
     "message": "Insérer un modèle",
     "description": "Context menu root item in compose body"
@@ -24,7 +23,6 @@
     "message": "Enregistrer comme modèle",
     "description": "Context menu item on a message in the message list"
   },
-
   "popupTitle": {
     "message": "Modèles",
     "description": "Popup heading"
@@ -41,7 +39,6 @@
     "message": "Gérer les modèles…",
     "description": "Button to open options page"
   },
-
   "optionsTitle": {
     "message": "TemplateWing — Gérer les modèles",
     "description": "Options page heading"
@@ -75,7 +72,7 @@
     "description": "Label for body textarea"
   },
   "optionsBack": {
-    "message": "\u2190 Retour",
+    "message": "← Retour",
     "description": "Back button to return to template list"
   },
   "optionsSave": {
@@ -104,12 +101,10 @@
       }
     }
   },
-
   "optionsSaveError": {
     "message": "Impossible d'enregistrer le modèle. Le stockage est peut-être plein — essayez de réduire la taille des pièces jointes ou de supprimer d'anciens modèles.",
     "description": "Error message when saving fails"
   },
-
   "optionsLabelAttachments": {
     "message": "Pièces jointes",
     "description": "Label for attachments section in editor"
@@ -156,7 +151,6 @@
     "message": "Remplacer le contenu existant",
     "description": "Option to replace existing email body with template body"
   },
-
   "popupAttachmentCount": {
     "message": "$COUNT$ pièce(s) jointe(s)",
     "description": "Attachment count shown in popup",
@@ -167,7 +161,6 @@
       }
     }
   },
-
   "optionsLabelCategory": {
     "message": "Catégorie (facultatif)",
     "description": "Label for category input"
@@ -184,7 +177,6 @@
     "message": "Tous",
     "description": "Option to show all categories in popup filter"
   },
-
   "optionsLabelTo": {
     "message": "À (Destinataires)",
     "description": "Label for To field"
@@ -201,7 +193,6 @@
     "message": "Séparez plusieurs destinataires par des virgules. Exemple : john@example.com, Jean Dupont <jean@example.com>",
     "description": "Help text for recipient fields"
   },
-
   "optionsLabelVariables": {
     "message": "Variables disponibles",
     "description": "Label for variables help section"
@@ -222,7 +213,6 @@
     "message": "{SENDER_EMAIL} — Votre adresse e-mail",
     "description": "Describes SENDER_EMAIL variable"
   },
-
   "optionsUsageCount": {
     "message": "Utilisé $COUNT$ fois",
     "description": "Usage count shown on template card",
@@ -259,7 +249,6 @@
     "message": "Fichier invalide. Veuillez sélectionner un fichier JSON TemplateWing valide.",
     "description": "Error message when an invalid file is imported"
   },
-
   "optionsLabelAccounts": {
     "message": "Comptes (facultatif)",
     "description": "Label for accounts/identities selection"
@@ -272,7 +261,6 @@
     "message": "Tous les comptes",
     "description": "Option to show template for all accounts"
   },
-
   "optionsLabelNestedTemplates": {
     "message": "Modèles imbriqués",
     "description": "Label for nested template help section"
@@ -289,7 +277,6 @@
     "message": "Sélectionnez un modèle à imbriquer…",
     "description": "Placeholder for nested template dropdown"
   },
-
   "importDialogTitle": {
     "message": "Résumé de l'importation",
     "description": "Title of the import confirmation dialog"
@@ -302,21 +289,30 @@
     "message": "$COUNT$ modèle(s) trouvé(s) dans le fichier",
     "description": "Total templates found in the import file",
     "placeholders": {
-      "count": { "content": "$1", "example": "5" }
+      "count": {
+        "content": "$1",
+        "example": "5"
+      }
     }
   },
   "importDialogInvalid": {
     "message": "$COUNT$ invalide(s) (seront ignoré(s))",
     "description": "Number of invalid entries in the import file",
     "placeholders": {
-      "count": { "content": "$1", "example": "1" }
+      "count": {
+        "content": "$1",
+        "example": "1"
+      }
     }
   },
   "importDialogDuplicates": {
     "message": "$COUNT$ avec des noms existants",
     "description": "Number of templates with names that already exist",
     "placeholders": {
-      "count": { "content": "$1", "example": "2" }
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
     }
   },
   "importModeAppend": {
@@ -355,12 +351,20 @@
     "message": "$ADDED$ ajouté(s), $SKIPPED$ ignoré(s), $REPLACED$ remplacé(s).",
     "description": "Result message after import completes",
     "placeholders": {
-      "added": { "content": "$1", "example": "3" },
-      "skipped": { "content": "$2", "example": "1" },
-      "replaced": { "content": "$3", "example": "0" }
+      "added": {
+        "content": "$1",
+        "example": "3"
+      },
+      "skipped": {
+        "content": "$2",
+        "example": "1"
+      },
+      "replaced": {
+        "content": "$3",
+        "example": "0"
+      }
     }
   },
-
   "validationNameRequired": {
     "message": "Le nom du modèle est requis.",
     "description": "Error when template name is empty"
@@ -369,10 +373,12 @@
     "message": "Destinataire(s) invalide(s) : $LIST$",
     "description": "Error when recipient email format is invalid",
     "placeholders": {
-      "list": { "content": "$1", "example": "bad-email, another" }
+      "list": {
+        "content": "$1",
+        "example": "bad-email, another"
+      }
     }
   },
-
   "attachmentSizeWarning": {
     "message": "Fichier volumineux",
     "description": "Short warning shown next to a large attachment"
@@ -381,17 +387,22 @@
     "message": "La taille totale des pièces jointes ($SIZE$) est importante. Cela peut augmenter considérablement l'utilisation du stockage.",
     "description": "Warning when total attachment size exceeds threshold",
     "placeholders": {
-      "size": { "content": "$1", "example": "12.5 MB" }
+      "size": {
+        "content": "$1",
+        "example": "12.5 MB"
+      }
     }
   },
   "attachmentReadError": {
     "message": "Impossible de lire le fichier « $NAME$ ».",
     "description": "Error when a file cannot be read during attachment",
     "placeholders": {
-      "name": { "content": "$1", "example": "document.pdf" }
+      "name": {
+        "content": "$1",
+        "example": "document.pdf"
+      }
     }
   },
-
   "optionsVariableDatetime": {
     "message": "{DATETIME} — Date et heure actuelles",
     "description": "Describes DATETIME variable"
@@ -437,5 +448,9 @@
   "notificationInsertFailedGeneric": {
     "message": "Le modèle n'a pas pu être inséré. Consultez la console d'erreurs pour plus de détails.",
     "description": "Notification body for a generic template insertion failure"
+  },
+  "validationBodyEmptyReplace": {
+    "message": "Avertissement : le corps est vide. Le mode remplacement supprimera le contenu du message d'origine.",
+    "description": "Warning shown when body is empty/whitespace in replace insert mode"
   }
 }

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -11,7 +11,6 @@
     "message": "Modelli",
     "description": "Tooltip for the compose action button"
   },
-
   "menuInsertTemplate": {
     "message": "Inserisci modello",
     "description": "Context menu root item in compose body"
@@ -24,7 +23,6 @@
     "message": "Salva come modello",
     "description": "Context menu item on a message in the message list"
   },
-
   "popupTitle": {
     "message": "Modelli",
     "description": "Popup heading"
@@ -41,7 +39,6 @@
     "message": "Gestisci modelli…",
     "description": "Button to open options page"
   },
-
   "optionsTitle": {
     "message": "TemplateWing — Gestisci modelli",
     "description": "Options page heading"
@@ -75,7 +72,7 @@
     "description": "Label for body textarea"
   },
   "optionsBack": {
-    "message": "\u2190 Indietro",
+    "message": "← Indietro",
     "description": "Back button to return to template list"
   },
   "optionsSave": {
@@ -104,12 +101,10 @@
       }
     }
   },
-
   "optionsSaveError": {
     "message": "Impossibile salvare il modello. Lo storage potrebbe essere pieno — prova a ridurre la dimensione degli allegati o a eliminare vecchi modelli.",
     "description": "Error message when saving fails"
   },
-
   "optionsLabelAttachments": {
     "message": "Allegati",
     "description": "Label for attachments section in editor"
@@ -156,7 +151,6 @@
     "message": "Sostituisci contenuto esistente",
     "description": "Option to replace existing email body with template body"
   },
-
   "popupAttachmentCount": {
     "message": "$COUNT$ allegato(i)",
     "description": "Attachment count shown in popup",
@@ -167,7 +161,6 @@
       }
     }
   },
-
   "optionsLabelCategory": {
     "message": "Categoria (opzionale)",
     "description": "Label for category input"
@@ -184,7 +177,6 @@
     "message": "Tutti",
     "description": "Option to show all categories in popup filter"
   },
-
   "optionsLabelTo": {
     "message": "A (Destinatari)",
     "description": "Label for To field"
@@ -201,7 +193,6 @@
     "message": "Separa più destinatari con virgole. Esempio: mario@esempio.it, Mario Rossi <mario@esempio.it>",
     "description": "Help text for recipient fields"
   },
-
   "optionsLabelVariables": {
     "message": "Variabili disponibili",
     "description": "Label for variables help section"
@@ -222,7 +213,6 @@
     "message": "{SENDER_EMAIL} — La tua email",
     "description": "Describes SENDER_EMAIL variable"
   },
-
   "optionsUsageCount": {
     "message": "Usato $COUNT$ volta/e",
     "description": "Usage count shown on template card",
@@ -259,7 +249,6 @@
     "message": "File non valido. Seleziona un file JSON TemplateWing valido.",
     "description": "Error message when an invalid file is imported"
   },
-
   "optionsLabelAccounts": {
     "message": "Account (opzionale)",
     "description": "Label for accounts/identities selection"
@@ -272,7 +261,6 @@
     "message": "Tutti gli account",
     "description": "Option to show template for all accounts"
   },
-
   "optionsLabelNestedTemplates": {
     "message": "Modelli annidati",
     "description": "Label for nested template help section"
@@ -289,7 +277,6 @@
     "message": "Seleziona un modello da annidare…",
     "description": "Placeholder for nested template dropdown"
   },
-
   "importDialogTitle": {
     "message": "Riepilogo importazione",
     "description": "Title of the import confirmation dialog"
@@ -302,21 +289,30 @@
     "message": "$COUNT$ modello(i) trovato(i) nel file",
     "description": "Total templates found in the import file",
     "placeholders": {
-      "count": { "content": "$1", "example": "5" }
+      "count": {
+        "content": "$1",
+        "example": "5"
+      }
     }
   },
   "importDialogInvalid": {
     "message": "$COUNT$ non valido(i) (verranno saltati)",
     "description": "Number of invalid entries in the import file",
     "placeholders": {
-      "count": { "content": "$1", "example": "1" }
+      "count": {
+        "content": "$1",
+        "example": "1"
+      }
     }
   },
   "importDialogDuplicates": {
     "message": "$COUNT$ con nomi già esistenti",
     "description": "Number of templates with names that already exist",
     "placeholders": {
-      "count": { "content": "$1", "example": "2" }
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
     }
   },
   "importModeAppend": {
@@ -355,12 +351,20 @@
     "message": "$ADDED$ aggiunto(i), $SKIPPED$ saltato(i), $REPLACED$ sostituito(i).",
     "description": "Result message after import completes",
     "placeholders": {
-      "added": { "content": "$1", "example": "3" },
-      "skipped": { "content": "$2", "example": "1" },
-      "replaced": { "content": "$3", "example": "0" }
+      "added": {
+        "content": "$1",
+        "example": "3"
+      },
+      "skipped": {
+        "content": "$2",
+        "example": "1"
+      },
+      "replaced": {
+        "content": "$3",
+        "example": "0"
+      }
     }
   },
-
   "validationNameRequired": {
     "message": "Il nome del modello è obbligatorio.",
     "description": "Error when template name is empty"
@@ -369,10 +373,12 @@
     "message": "Destinatario(i) non valido(i): $LIST$",
     "description": "Error when recipient email format is invalid",
     "placeholders": {
-      "list": { "content": "$1", "example": "bad-email, another" }
+      "list": {
+        "content": "$1",
+        "example": "bad-email, another"
+      }
     }
   },
-
   "attachmentSizeWarning": {
     "message": "File grande",
     "description": "Short warning shown next to a large attachment"
@@ -381,17 +387,22 @@
     "message": "La dimensione totale degli allegati ($SIZE$) è grande. Questo può aumentare significativamente l'uso dello storage.",
     "description": "Warning when total attachment size exceeds threshold",
     "placeholders": {
-      "size": { "content": "$1", "example": "12.5 MB" }
+      "size": {
+        "content": "$1",
+        "example": "12.5 MB"
+      }
     }
   },
   "attachmentReadError": {
     "message": "Impossibile leggere il file «$NAME$».",
     "description": "Error when a file cannot be read during attachment",
     "placeholders": {
-      "name": { "content": "$1", "example": "document.pdf" }
+      "name": {
+        "content": "$1",
+        "example": "document.pdf"
+      }
     }
   },
-
   "optionsVariableDatetime": {
     "message": "{DATETIME} — Data e ora attuali",
     "description": "Describes DATETIME variable"
@@ -437,5 +448,9 @@
   "notificationInsertFailedGeneric": {
     "message": "Impossibile inserire il modello. Consulta la console degli errori per i dettagli.",
     "description": "Notification body for a generic template insertion failure"
+  },
+  "validationBodyEmptyReplace": {
+    "message": "Avvertimento: il corpo è vuoto. La modalità sostituzione rimuoverà il contenuto del messaggio originale.",
+    "description": "Warning shown when body is empty/whitespace in replace insert mode"
   }
 }

--- a/_locales/nl/messages.json
+++ b/_locales/nl/messages.json
@@ -11,7 +11,6 @@
     "message": "Sjablonen",
     "description": "Tooltip for the compose action button"
   },
-
   "menuInsertTemplate": {
     "message": "Sjabloon invoegen",
     "description": "Context menu root item in compose body"
@@ -24,7 +23,6 @@
     "message": "Opslaan als sjabloon",
     "description": "Context menu item on a message in the message list"
   },
-
   "popupTitle": {
     "message": "Sjablonen",
     "description": "Popup heading"
@@ -41,7 +39,6 @@
     "message": "Sjablonen beheren…",
     "description": "Button to open options page"
   },
-
   "optionsTitle": {
     "message": "TemplateWing — Sjablonen beheren",
     "description": "Options page heading"
@@ -75,7 +72,7 @@
     "description": "Label for body textarea"
   },
   "optionsBack": {
-    "message": "\u2190 Terug",
+    "message": "← Terug",
     "description": "Back button to return to template list"
   },
   "optionsSave": {
@@ -104,12 +101,10 @@
       }
     }
   },
-
   "optionsSaveError": {
     "message": "Sjabloon kon niet worden opgeslagen. Opslagruimte is mogelijk vol — probeer bijlagen te verkleinen of oude sjablonen te verwijderen.",
     "description": "Error message when saving fails"
   },
-
   "optionsLabelAttachments": {
     "message": "Bijlagen",
     "description": "Label for attachments section in editor"
@@ -156,7 +151,6 @@
     "message": "Bestaande inhoud vervangen",
     "description": "Option to replace existing email body with template body"
   },
-
   "popupAttachmentCount": {
     "message": "$COUNT$ bijlage(n)",
     "description": "Attachment count shown in popup",
@@ -167,7 +161,6 @@
       }
     }
   },
-
   "optionsLabelCategory": {
     "message": "Categorie (optioneel)",
     "description": "Label for category input"
@@ -184,7 +177,6 @@
     "message": "Alle",
     "description": "Option to show all categories in popup filter"
   },
-
   "optionsLabelTo": {
     "message": "Aan (Ontvangers)",
     "description": "Label for To field"
@@ -201,7 +193,6 @@
     "message": "Meerdere ontvangers scheiden met komma's. Voorbeeld: jan@voorbeeld.nl, Jan de Vries <jan@voorbeeld.nl>",
     "description": "Help text for recipient fields"
   },
-
   "optionsLabelVariables": {
     "message": "Beschikbare variabelen",
     "description": "Label for variables help section"
@@ -222,7 +213,6 @@
     "message": "{SENDER_EMAIL} — Uw e-mail",
     "description": "Describes SENDER_EMAIL variable"
   },
-
   "optionsUsageCount": {
     "message": "$COUNT$ keer gebruikt",
     "description": "Usage count shown on template card",
@@ -259,7 +249,6 @@
     "message": "Ongeldig bestand. Selecteer een geldig TemplateWing JSON-bestand.",
     "description": "Error message when an invalid file is imported"
   },
-
   "optionsLabelAccounts": {
     "message": "Accounts (optioneel)",
     "description": "Label for accounts/identities selection"
@@ -272,7 +261,6 @@
     "message": "Alle accounts",
     "description": "Option to show template for all accounts"
   },
-
   "optionsLabelNestedTemplates": {
     "message": "Geneste sjablonen",
     "description": "Label for nested template help section"
@@ -289,7 +277,6 @@
     "message": "Selecteer een sjabloon om te nesten…",
     "description": "Placeholder for nested template dropdown"
   },
-
   "importDialogTitle": {
     "message": "Import-overzicht",
     "description": "Title of the import confirmation dialog"
@@ -302,21 +289,30 @@
     "message": "$COUNT$ sjabloon/sjablonen gevonden in bestand",
     "description": "Total templates found in the import file",
     "placeholders": {
-      "count": { "content": "$1", "example": "5" }
+      "count": {
+        "content": "$1",
+        "example": "5"
+      }
     }
   },
   "importDialogInvalid": {
     "message": "$COUNT$ ongeldig (worden overgeslagen)",
     "description": "Number of invalid entries in the import file",
     "placeholders": {
-      "count": { "content": "$1", "example": "1" }
+      "count": {
+        "content": "$1",
+        "example": "1"
+      }
     }
   },
   "importDialogDuplicates": {
     "message": "$COUNT$ met bestaande namen",
     "description": "Number of templates with names that already exist",
     "placeholders": {
-      "count": { "content": "$1", "example": "2" }
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
     }
   },
   "importModeAppend": {
@@ -355,12 +351,20 @@
     "message": "$ADDED$ toegevoegd, $SKIPPED$ overgeslagen, $REPLACED$ vervangen.",
     "description": "Result message after import completes",
     "placeholders": {
-      "added": { "content": "$1", "example": "3" },
-      "skipped": { "content": "$2", "example": "1" },
-      "replaced": { "content": "$3", "example": "0" }
+      "added": {
+        "content": "$1",
+        "example": "3"
+      },
+      "skipped": {
+        "content": "$2",
+        "example": "1"
+      },
+      "replaced": {
+        "content": "$3",
+        "example": "0"
+      }
     }
   },
-
   "validationNameRequired": {
     "message": "Sjabloonnaam is vereist.",
     "description": "Error when template name is empty"
@@ -369,10 +373,12 @@
     "message": "Ongeldige ontvanger(s): $LIST$",
     "description": "Error when recipient email format is invalid",
     "placeholders": {
-      "list": { "content": "$1", "example": "bad-email, another" }
+      "list": {
+        "content": "$1",
+        "example": "bad-email, another"
+      }
     }
   },
-
   "attachmentSizeWarning": {
     "message": "Groot bestand",
     "description": "Short warning shown next to a large attachment"
@@ -381,17 +387,22 @@
     "message": "De totale grootte van de bijlagen ($SIZE$) is groot. Dit kan het opslaggebruik aanzienlijk verhogen.",
     "description": "Warning when total attachment size exceeds threshold",
     "placeholders": {
-      "size": { "content": "$1", "example": "12.5 MB" }
+      "size": {
+        "content": "$1",
+        "example": "12.5 MB"
+      }
     }
   },
   "attachmentReadError": {
     "message": "Kan bestand «$NAME$» niet lezen.",
     "description": "Error when a file cannot be read during attachment",
     "placeholders": {
-      "name": { "content": "$1", "example": "document.pdf" }
+      "name": {
+        "content": "$1",
+        "example": "document.pdf"
+      }
     }
   },
-
   "optionsVariableDatetime": {
     "message": "{DATETIME} — Huidige datum en tijd",
     "description": "Describes DATETIME variable"
@@ -437,5 +448,9 @@
   "notificationInsertFailedGeneric": {
     "message": "Het sjabloon kon niet worden ingevoegd. Raadpleeg de foutconsole voor details.",
     "description": "Notification body for a generic template insertion failure"
+  },
+  "validationBodyEmptyReplace": {
+    "message": "Waarschuwing: de body is leeg. De vervangingsmodus verwijdert de oorspronkelijke berichtinhoud.",
+    "description": "Warning shown when body is empty/whitespace in replace insert mode"
   }
 }

--- a/_locales/pt/messages.json
+++ b/_locales/pt/messages.json
@@ -11,7 +11,6 @@
     "message": "Modelos",
     "description": "Tooltip for the compose action button"
   },
-
   "menuInsertTemplate": {
     "message": "Inserir modelo",
     "description": "Context menu root item in compose body"
@@ -24,7 +23,6 @@
     "message": "Guardar como modelo",
     "description": "Context menu item on a message in the message list"
   },
-
   "popupTitle": {
     "message": "Modelos",
     "description": "Popup heading"
@@ -41,7 +39,6 @@
     "message": "Gerir modelos…",
     "description": "Button to open options page"
   },
-
   "optionsTitle": {
     "message": "TemplateWing — Gerir Modelos",
     "description": "Options page heading"
@@ -75,7 +72,7 @@
     "description": "Label for body textarea"
   },
   "optionsBack": {
-    "message": "\u2190 Voltar",
+    "message": "← Voltar",
     "description": "Back button to return to template list"
   },
   "optionsSave": {
@@ -104,12 +101,10 @@
       }
     }
   },
-
   "optionsSaveError": {
     "message": "Não foi possível guardar o modelo. O armazenamento pode estar cheio — tente reduzir o tamanho dos anexos ou eliminar modelos antigos.",
     "description": "Error message when saving fails"
   },
-
   "optionsLabelAttachments": {
     "message": "Anexos",
     "description": "Label for attachments section in editor"
@@ -156,7 +151,6 @@
     "message": "Substituir conteúdo existente",
     "description": "Option to replace existing email body with template body"
   },
-
   "popupAttachmentCount": {
     "message": "$COUNT$ anexo(s)",
     "description": "Attachment count shown in popup",
@@ -167,7 +161,6 @@
       }
     }
   },
-
   "optionsLabelCategory": {
     "message": "Categoria (opcional)",
     "description": "Label for category input"
@@ -184,7 +177,6 @@
     "message": "Todos",
     "description": "Option to show all categories in popup filter"
   },
-
   "optionsLabelTo": {
     "message": "Para (Destinatários)",
     "description": "Label for To field"
@@ -201,7 +193,6 @@
     "message": "Separe vários destinatários com vírgulas. Exemplo: joao@exemplo.pt, João Silva <joao@exemplo.pt>",
     "description": "Help text for recipient fields"
   },
-
   "optionsLabelVariables": {
     "message": "Variáveis disponíveis",
     "description": "Label for variables help section"
@@ -222,7 +213,6 @@
     "message": "{SENDER_EMAIL} — O seu e-mail",
     "description": "Describes SENDER_EMAIL variable"
   },
-
   "optionsUsageCount": {
     "message": "Usado $COUNT$ vez/vezes",
     "description": "Usage count shown on template card",
@@ -259,7 +249,6 @@
     "message": "Ficheiro inválido. Por favor, selecione um ficheiro JSON TemplateWing válido.",
     "description": "Error message when an invalid file is imported"
   },
-
   "optionsLabelAccounts": {
     "message": "Contas (opcional)",
     "description": "Label for accounts/identities selection"
@@ -272,7 +261,6 @@
     "message": "Todas as contas",
     "description": "Option to show template for all accounts"
   },
-
   "optionsLabelNestedTemplates": {
     "message": "Modelos aninhados",
     "description": "Label for nested template help section"
@@ -289,7 +277,6 @@
     "message": "Selecione um modelo para aninhar…",
     "description": "Placeholder for nested template dropdown"
   },
-
   "importDialogTitle": {
     "message": "Resumo da importação",
     "description": "Title of the import confirmation dialog"
@@ -302,21 +289,30 @@
     "message": "$COUNT$ modelo(s) encontrado(s) no ficheiro",
     "description": "Total templates found in the import file",
     "placeholders": {
-      "count": { "content": "$1", "example": "5" }
+      "count": {
+        "content": "$1",
+        "example": "5"
+      }
     }
   },
   "importDialogInvalid": {
     "message": "$COUNT$ inválido(s) (serão ignorados)",
     "description": "Number of invalid entries in the import file",
     "placeholders": {
-      "count": { "content": "$1", "example": "1" }
+      "count": {
+        "content": "$1",
+        "example": "1"
+      }
     }
   },
   "importDialogDuplicates": {
     "message": "$COUNT$ com nomes já existentes",
     "description": "Number of templates with names that already exist",
     "placeholders": {
-      "count": { "content": "$1", "example": "2" }
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
     }
   },
   "importModeAppend": {
@@ -355,12 +351,20 @@
     "message": "$ADDED$ adicionado(s), $SKIPPED$ ignorado(s), $REPLACED$ substituído(s).",
     "description": "Result message after import completes",
     "placeholders": {
-      "added": { "content": "$1", "example": "3" },
-      "skipped": { "content": "$2", "example": "1" },
-      "replaced": { "content": "$3", "example": "0" }
+      "added": {
+        "content": "$1",
+        "example": "3"
+      },
+      "skipped": {
+        "content": "$2",
+        "example": "1"
+      },
+      "replaced": {
+        "content": "$3",
+        "example": "0"
+      }
     }
   },
-
   "validationNameRequired": {
     "message": "O nome do modelo é obrigatório.",
     "description": "Error when template name is empty"
@@ -369,10 +373,12 @@
     "message": "Destinatário(s) inválido(s): $LIST$",
     "description": "Error when recipient email format is invalid",
     "placeholders": {
-      "list": { "content": "$1", "example": "bad-email, another" }
+      "list": {
+        "content": "$1",
+        "example": "bad-email, another"
+      }
     }
   },
-
   "attachmentSizeWarning": {
     "message": "Ficheiro grande",
     "description": "Short warning shown next to a large attachment"
@@ -381,17 +387,22 @@
     "message": "O tamanho total dos anexos ($SIZE$) é grande. Isto pode aumentar significativamente o uso de armazenamento.",
     "description": "Warning when total attachment size exceeds threshold",
     "placeholders": {
-      "size": { "content": "$1", "example": "12.5 MB" }
+      "size": {
+        "content": "$1",
+        "example": "12.5 MB"
+      }
     }
   },
   "attachmentReadError": {
     "message": "Não foi possível ler o ficheiro «$NAME$».",
     "description": "Error when a file cannot be read during attachment",
     "placeholders": {
-      "name": { "content": "$1", "example": "document.pdf" }
+      "name": {
+        "content": "$1",
+        "example": "document.pdf"
+      }
     }
   },
-
   "optionsVariableDatetime": {
     "message": "{DATETIME} — Data e hora atuais",
     "description": "Describes DATETIME variable"
@@ -437,5 +448,9 @@
   "notificationInsertFailedGeneric": {
     "message": "Não foi possível inserir o modelo. Consulte o console de erros para mais detalhes.",
     "description": "Notification body for a generic template insertion failure"
+  },
+  "validationBodyEmptyReplace": {
+    "message": "Aviso: o corpo está vazio. O modo substituição removerá o conteúdo da mensagem original.",
+    "description": "Warning shown when body is empty/whitespace in replace insert mode"
   }
 }

--- a/options/options.css
+++ b/options/options.css
@@ -342,6 +342,23 @@ h1 {
   font-size: 13px;
 }
 
+.inline-error {
+  color: var(--color-error);
+  font-size: 12px;
+  margin-top: 4px;
+  margin-bottom: 8px;
+}
+
+.editor-warning {
+  margin-top: 6px;
+  padding: 8px 12px;
+  background: #fef3c7;
+  border: 1px solid #f59e0b;
+  border-radius: 4px;
+  color: #92400e;
+  font-size: 13px;
+}
+
 .editor-actions {
   display: flex;
   justify-content: flex-end;

--- a/options/options.html
+++ b/options/options.html
@@ -46,6 +46,7 @@
       <div class="editor-form">
         <label data-i18n="optionsLabelName"></label>
         <input type="text" id="editor-name">
+        <div id="editor-name-error" class="inline-error" hidden></div>
 
         <label data-i18n="optionsLabelCategory"></label>
         <input type="text" id="editor-category" list="category-suggestions"
@@ -63,12 +64,15 @@
 
         <label data-i18n="optionsLabelTo"></label>
         <input type="text" id="editor-to" placeholder="recipient@example.com, Name <email@example.com>">
+        <div id="editor-to-error" class="inline-error" hidden></div>
 
         <label data-i18n="optionsLabelCc"></label>
         <input type="text" id="editor-cc" placeholder="recipient@example.com">
+        <div id="editor-cc-error" class="inline-error" hidden></div>
 
         <label data-i18n="optionsLabelBcc"></label>
         <input type="text" id="editor-bcc" placeholder="recipient@example.com">
+        <div id="editor-bcc-error" class="inline-error" hidden></div>
 
         <div class="recipient-help" data-i18n="optionsRecipientHelp"></div>
 
@@ -80,6 +84,7 @@
         </select>
 
         <label data-i18n="optionsLabelBody"></label>
+        <div id="editor-body-warning" class="editor-warning" hidden></div>
         <div class="editor-toolbar">
           <button type="button" class="toolbar-btn" data-cmd="bold" title="Bold"><b>B</b></button>
           <button type="button" class="toolbar-btn" data-cmd="italic" title="Italic"><i>I</i></button>

--- a/options/options.js
+++ b/options/options.js
@@ -15,6 +15,7 @@ import {
 
 let editingId = null;
 let pendingAttachments = [];
+let bodyEmptyAcknowledged = false;
 
 function localize() {
   for (const el of document.querySelectorAll("[data-i18n]")) {
@@ -221,7 +222,6 @@ function getTotalAttachmentSize() {
   return pendingAttachments.reduce((sum, a) => sum + (a.size || 0), 0);
 }
 
-// Issue #18: Renders per-file (>=5MB badge) and total (>=10MB) attachment warnings
 function renderAttachments() {
   const list = document.getElementById("attachment-list");
   list.replaceChildren();
@@ -314,6 +314,7 @@ async function addFiles(files) {
 async function openEditor(id, prefill = null) {
   editingId = id || null;
   pendingAttachments = [];
+  bodyEmptyAcknowledged = false;
   const title = document.getElementById("editor-title");
   const nameInput = document.getElementById("editor-name");
   const categoryInput = document.getElementById("editor-category");
@@ -377,6 +378,7 @@ async function openEditor(id, prefill = null) {
 function closeEditor() {
   editingId = null;
   pendingAttachments = [];
+  bodyEmptyAcknowledged = false;
   document.getElementById("search-input").value = "";
   showView("list");
 }
@@ -387,6 +389,7 @@ async function duplicateTemplate(id) {
 
   editingId = null;
   pendingAttachments = (template.attachments || []).map((a) => ({ ...a }));
+  bodyEmptyAcknowledged = false;
 
   const title = document.getElementById("editor-title");
   const nameInput = document.getElementById("editor-name");
@@ -443,12 +446,31 @@ function showEditorError(message) {
   errorEl.hidden = false;
 }
 
+function showInlineError(fieldId, message) {
+  const errorEl = document.getElementById(`${fieldId}-error`);
+  if (errorEl) {
+    errorEl.textContent = message;
+    errorEl.hidden = false;
+  }
+}
+
 function clearEditorErrors() {
   const errorEl = document.getElementById("editor-error");
   errorEl.hidden = true;
   errorEl.textContent = "";
   for (const el of document.querySelectorAll(".field-error")) {
     el.classList.remove("field-error");
+  }
+  // Clear inline errors
+  for (const el of document.querySelectorAll(".inline-error")) {
+    el.hidden = true;
+    el.textContent = "";
+  }
+  // Clear body warning
+  const bodyWarning = document.getElementById("editor-body-warning");
+  if (bodyWarning) {
+    bodyWarning.hidden = true;
+    bodyWarning.textContent = "";
   }
 }
 
@@ -467,7 +489,7 @@ async function handleSave() {
   // Validate name
   if (!name) {
     nameInput.classList.add("field-error");
-    showEditorError(messenger.i18n.getMessage("validationNameRequired"));
+    showInlineError("editor-name", messenger.i18n.getMessage("validationNameRequired"));
     nameInput.focus();
     return;
   }
@@ -479,7 +501,7 @@ async function handleSave() {
   );
   if (duplicate) {
     nameInput.classList.add("field-error");
-    showEditorError(messenger.i18n.getMessage("validationDuplicateName"));
+    showInlineError("editor-name", messenger.i18n.getMessage("validationDuplicateName"));
     nameInput.focus();
     return;
   }
@@ -495,12 +517,18 @@ async function handleSave() {
     ...bccResult.invalid,
   ];
   if (allInvalid.length > 0) {
-    if (toResult.invalid.length) toInput.classList.add("field-error");
-    if (ccResult.invalid.length) ccInput.classList.add("field-error");
-    if (bccResult.invalid.length) bccInput.classList.add("field-error");
-    showEditorError(
-      messenger.i18n.getMessage("validationInvalidRecipients", allInvalid.join(", "))
-    );
+    if (toResult.invalid.length) {
+      toInput.classList.add("field-error");
+      showInlineError("editor-to", messenger.i18n.getMessage("validationInvalidRecipients", toResult.invalid.join(", ")));
+    }
+    if (ccResult.invalid.length) {
+      ccInput.classList.add("field-error");
+      showInlineError("editor-cc", messenger.i18n.getMessage("validationInvalidRecipients", ccResult.invalid.join(", ")));
+    }
+    if (bccResult.invalid.length) {
+      bccInput.classList.add("field-error");
+      showInlineError("editor-bcc", messenger.i18n.getMessage("validationInvalidRecipients", bccResult.invalid.join(", ")));
+    }
     return;
   }
 
@@ -509,6 +537,18 @@ async function handleSave() {
   const bcc = parseRecipients(bccInput.value);
 
   const insertMode = document.getElementById("editor-insert-mode").value;
+
+  // Block save on empty body in replace mode, unless user has already confirmed.
+  if (insertMode === "replace") {
+    const bodyText = document.getElementById("editor-body").innerText.trim();
+    if (!bodyText && !bodyEmptyAcknowledged) {
+      const bodyWarning = document.getElementById("editor-body-warning");
+      bodyWarning.textContent = messenger.i18n.getMessage("validationBodyEmptyReplace");
+      bodyWarning.hidden = false;
+      bodyEmptyAcknowledged = true;
+      return;
+    }
+  }
 
   const identitiesSelect = document.getElementById("editor-identities");
   const identities = Array.from(identitiesSelect.selectedOptions).map((opt) => opt.value);
@@ -792,6 +832,11 @@ document.addEventListener("selectionchange", () => {
 });
 
 document.getElementById("editor-body").addEventListener("keyup", updateToolbarState);
+
+document.getElementById("editor-body").addEventListener("input", () => {
+  const warning = document.getElementById("editor-body-warning");
+  if (warning && !warning.hidden) warning.hidden = true;
+});
 
 // ---- v2.2: Paste sanitization mode ----
 


### PR DESCRIPTION
## Summary

Improve input validation in the template editor to reduce invalid saved templates.

## Changes

- Validate recipient-like fields (to, cc, bcc) before save
- Validate required fields with consistent inline error feedback
- Add warning for empty/whitespace body in replace mode

## Testing

- All tests pass
- Lint passes with 88 consistent keys across all locales

Fixes JuliaKalder/TemplateWing#17