### PR TITLE
fix: add type guards for non-name fields in analyseImport

### DIFF
--- a/modules/validation.js
+++ b/modules/validation.js
@@ -69,6 +69,13 @@ export function analyseImport(importedTemplates, existingTemplates) {
       duplicates.set(key, t);
     }
     seenNames.set(key, t);
+    if (t.body != null && typeof t.body !== "string") { invalid++; continue; }
+    if (t.subject != null && typeof t.subject !== "string") { invalid++; continue; }
+    if (t.to != null && !Array.isArray(t.to)) { invalid++; continue; }
+    if (t.cc != null && !Array.isArray(t.cc)) { invalid++; continue; }
+    if (t.bcc != null && !Array.isArray(t.bcc)) { invalid++; continue; }
+    if (t.identities != null && !Array.isArray(t.identities)) { invalid++; continue; }
+    if (t.attachments != null && !Array.isArray(t.attachments)) { invalid++; continue; }
     valid.push(t);
   }
 


### PR DESCRIPTION
## Summary

- Adds type guards in `analyseImport()` for non-name fields (`body`, `subject`, `to`, `cc`, `bcc`, `identities`, `attachments`)
- Templates with wrong-typed fields are now counted as invalid and skipped rather than forwarded to the compose API with incorrect types

## Changes

- `modules/validation.js`: Added 7 type guard checks before `valid.push(t)` in the `analyseImport()` loop

## Test plan

- [x] All 96 existing tests pass (`npm test`)
- [x] The `analyseImport` test suite (6 tests) continues to pass

Fixes #162