### PR TITLE
fix: use immutable visited Set copy in resolveNestedTemplates

### DIFF
--- a/modules/template-insert.js
+++ b/modules/template-insert.js
@@ -145,7 +145,9 @@ export const TEMPLATE_INCLUDE_REGEX = /\{\{template(id)?:([^}]+)\}\}/gi;
  * Resolve nested template includes in text.
  * Syntax: {{template:Template Name}} or {{templateid:abc123}}
  * @param {string} text - Text containing template includes
- * @param {Set} visited - Set of visited template IDs to detect circular references
+ * @param {Set} visited - Set of visited template IDs to detect circular references.
+ *   Treated as immutable: a new Set copy is passed to each recursive call so the
+ *   caller's Set is never mutated and is never left dirty if recursion throws.
  * @param {Map} templatesById - Map of template ID to template object
  * @param {Map} templatesByName - Map of template name (lowercase) to template object
  * @returns {Promise<string>} Text with includes resolved
@@ -185,14 +187,12 @@ export async function resolveNestedTemplates(text, visited, templatesById, templ
       throw new Error(`Circular reference detected: ${nestedTemplate.name}`);
     }
 
-    visited.add(nestedTemplate.id);
     const nestedContent = await resolveNestedTemplates(
       nestedTemplate.body || "",
-      visited,
+      new Set([...visited, nestedTemplate.id]),
       templatesById,
       templatesByName
     );
-    visited.delete(nestedTemplate.id);
 
     resolved = resolved.replace(fullMatch, nestedContent);
   }


### PR DESCRIPTION
## Summary

- Replace the mutable `visited.add()` / `visited.delete()` pattern in `resolveNestedTemplates` with an immutable copy: `new Set([...visited, nestedTemplate.id])` passed to the recursive call.
- Remove the `visited.delete()` call entirely — no mutation of the caller's Set occurs at any point.
- Update the JSDoc for the `visited` parameter to state it is treated as immutable.

## Why

The original code mutated the caller's `visited` Set around each recursive call. If the recursive call threw (e.g., due to a circular-reference error deeper in the chain), the `visited.delete()` cleanup was skipped, leaving the Set in a dirty state for any subsequent sibling iterations in the same call frame.

The immutable-copy pattern eliminates the mutation entirely: each recursive frame gets its own snapshot of the ancestor set, and a throw propagates cleanly without any side-effects on the parent frame's Set.

Fixes JuliaKalder/TemplateWing#164

## Test plan

- [ ] All existing tests pass (`npm test` — 96/96 pass, including the `resolveNestedTemplates` circular-reference suite)
- [ ] No new failing tests