### PR TITLE
fix: make implicit append else branch explicit with console.warn

### DIFF
--- a/modules/template-insert.js
+++ b/modules/template-insert.js
@@ -322,7 +322,11 @@ export async function insertTemplateIntoTab(tabId, template) {
     } else if (mode === "prepend") {
       const existing = await messenger.compose.getComposeDetails(tabId);
       details.body = body + (existing.body || "");
+    } else if (mode === "append") {
+      const existing = await messenger.compose.getComposeDetails(tabId);
+      details.body = (existing.body || "") + body;
     } else {
+      console.warn(`TemplateWing: unknown insertMode "${mode}", falling back to append`);
       const existing = await messenger.compose.getComposeDetails(tabId);
       details.body = (existing.body || "") + body;
     }


### PR DESCRIPTION
## Summary

Changed the implicit `else` at template-insert.js:325-328 to an explicit `else if (mode === "append")` branch with a `console.warn` for unknown insertMode values. This makes the code self-documenting and prevents silent fallback behavior for any future new insertMode values.

## Changes

- `modules/template-insert.js`: Made the append-mode else branch explicit with console.warn fallback for unknown modes

## Testing

- Verified JavaScript syntax with node --check
- Code follows existing patterns in the same function

Fixes JuliaKalder/TemplateWing#166