### PR TITLE
fix: pin GitHub Actions to immutable commit SHAs (#34)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
       - linux
       - x64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af  # v4.1.0
         with:
           node-version: "20"
 


### PR DESCRIPTION
## Summary

Pins `actions/checkout` and `actions/setup-node` to full immutable commit SHAs instead of mutable `@v4` floating tags, eliminating the supply chain risk described in #34.

If a tag is overwritten by a compromised maintainer, a pinned SHA is unaffected — the exact code that ran when the SHA was recorded is what continues to run.

## Changes

- `.github/workflows/ci.yml`: replaced `@v4` tags with full commit SHAs and inline version comments
  - `actions/checkout@v4` → `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2`
  - `actions/setup-node@v4` → `actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af  # v4.1.0`
- `.github/dependabot.yml`: new file — weekly Dependabot updates for GitHub Actions to keep pinned SHAs current

## Testing

YAML structure validated. No logic changes — only action reference format updated from mutable tags to immutable SHAs.

Fixes JuliaKalder/TemplateWing#34