### PR TITLE
fix: add null guard for window.getSelection() in options.js (#159)

### DIFF
--- a/options/options.js
+++ b/options/options.js
@@ -207,7 +207,7 @@ function insertNestedTemplate() {
   editor.focus();
 
   const sel = window.getSelection();
-  if (sel.rangeCount > 0) {
+  if (sel && sel.rangeCount > 0) {
     const range = sel.getRangeAt(0);
     range.deleteContents();
     range.insertNode(document.createTextNode(includeText));
@@ -934,7 +934,7 @@ for (const chip of document.querySelectorAll(".variable-chip[data-var]")) {
     editor.focus();
 
     const sel = window.getSelection();
-    if (sel.rangeCount > 0) {
+    if (sel && sel.rangeCount > 0) {
       const range = sel.getRangeAt(0);
       range.deleteContents();
       range.insertNode(document.createTextNode(varText));


### PR DESCRIPTION
## Summary

Adds null guards at two callsites in `options.js` where `window.getSelection()` is accessed without checking for null first, consistent with the defensive pattern already used in `compose-script.js`.

## Changes

- `options.js` line 210: `if (sel.rangeCount > 0)` → `if (sel && sel.rangeCount > 0)` in `insertNestedTemplate()`
- `options.js` line 937: same fix in the variable chip click handler

## Testing

Minimal 1-character-equivalent change per callsite (add `sel && ` before `sel.rangeCount`). All 96 existing tests pass. The fix brings `options.js` in line with the null-safe pattern already used in `compose-script.js:84-85`.

Fixes JuliaKalder/TemplateWing#159