### PR TITLE
fix: replace .then() chain with async/await in popup.js init

### DIFF
--- a/popup/popup.js
+++ b/popup/popup.js
@@ -213,4 +213,5 @@ document.getElementById("btn-manage").addEventListener("click", async () => {
 });
 
 localize();
-renderTemplateList().then(() => populateCategoryFilter());
+await renderTemplateList();
+await populateCategoryFilter();


### PR DESCRIPTION
## Summary

Replaces the sole `.then()` promise chain in `popup/popup.js:216` with top-level `await`, matching the style used everywhere else in the codebase and in `options/options.js`.

## Changes

- `popup/popup.js`: replaced `renderTemplateList().then(() => populateCategoryFilter())` with two sequential `await` calls

## Testing

- All 96 existing tests pass (`npm test`)
- Verified the change is functionally equivalent (same execution order preserved)
- Confirmed `<script type="module">` context allows top-level `await`
- Searched codebase to confirm this was the only `.then()` usage

Fixes JuliaKalder/TemplateWing#160