### PR TITLE
refactor: move duplicate-name enforcement from UI layer to saveTemplate

### DIFF
--- a/modules/template-store.js
+++ b/modules/template-store.js
@@ -125,12 +125,21 @@ export async function getTemplate(id) {
   };
 }
 
-/** Save (create or update) a template. Throws if name is missing. */
+/** Save (create or update) a template. Throws if name is missing or duplicate. */
 export async function saveTemplate(template) {
   if (!template || typeof template.name !== "string" || !template.name.trim()) {
     throw new TypeError("template.name must be a non-empty string");
   }
   const templates = await getTemplates();
+  const nameLower = template.name.trim().toLowerCase();
+  const conflict = templates.find(
+    (t) => t.name.toLowerCase() === nameLower && t.id !== template.id
+  );
+  if (conflict) {
+    const err = new Error("A template with this name already exists");
+    err.code = "DUPLICATE_NAME";
+    throw err;
+  }
   const now = new Date().toISOString();
 
   if (template.id) {

--- a/options/options.js
+++ b/options/options.js
@@ -560,18 +560,6 @@ async function handleSave() {
     return;
   }
 
-  // Check for duplicate name
-  const allTemplates = await getTemplates();
-  const duplicate = allTemplates.find(
-    (t) => t.name.toLowerCase() === name.toLowerCase() && t.id !== editingId
-  );
-  if (duplicate) {
-    nameInput.classList.add("field-error");
-    showInlineError("editor-name", messenger.i18n.getMessage("validationDuplicateName"));
-    nameInput.focus();
-    return;
-  }
-
   // Validate recipients
   const toResult = validateRecipients(toInput.value);
   const ccResult = validateRecipients(ccInput.value);
@@ -644,6 +632,12 @@ async function handleSave() {
   try {
     await saveTemplate(template);
   } catch (err) {
+    if (err.code === "DUPLICATE_NAME") {
+      nameInput.classList.add("field-error");
+      showInlineError("editor-name", messenger.i18n.getMessage("validationDuplicateName"));
+      nameInput.focus();
+      return;
+    }
     console.error("TemplateWing: save failed", err);
     showEditorError(messenger.i18n.getMessage("optionsSaveError"));
     return;

--- a/tests/template-store.test.js
+++ b/tests/template-store.test.js
@@ -219,6 +219,47 @@ describe("saveTemplate / getTemplate / deleteTemplate", () => {
   it("trackUsage on an unknown id is a no-op", async () => {
     await assert.doesNotReject(trackUsage("nope"));
   });
+
+  it("rejects a new template whose name duplicates an existing one (case-insensitive)", async () => {
+    await saveTemplate({ name: "Hello World", body: "" });
+    await assert.rejects(
+      () => saveTemplate({ name: "hello world", body: "different" }),
+      (err) => {
+        assert.strictEqual(err.code, "DUPLICATE_NAME");
+        return true;
+      }
+    );
+  });
+
+  it("rejects updating a template to a name used by a different template", async () => {
+    const a = await saveTemplate({ name: "Alpha", body: "" });
+    await saveTemplate({ name: "Beta", body: "" });
+    await assert.rejects(
+      () => saveTemplate({ id: a.id, name: "Beta", body: "updated" }),
+      (err) => {
+        assert.strictEqual(err.code, "DUPLICATE_NAME");
+        return true;
+      }
+    );
+  });
+
+  it("allows updating a template to keep its own name", async () => {
+    const saved = await saveTemplate({ name: "Gamma", body: "" });
+    await assert.doesNotReject(() =>
+      saveTemplate({ id: saved.id, name: "Gamma", body: "updated" })
+    );
+  });
+
+  it("name uniqueness check is case-insensitive", async () => {
+    await saveTemplate({ name: "CaseSensitive", body: "" });
+    await assert.rejects(
+      () => saveTemplate({ name: "CASESENSITIVE", body: "" }),
+      (err) => {
+        assert.strictEqual(err.code, "DUPLICATE_NAME");
+        return true;
+      }
+    );
+  });
 });
 
 // ---- Schema migration runs via the store when version is stale ----


### PR DESCRIPTION
## Summary

- Adds a case-insensitive duplicate-name check to `saveTemplate` in `modules/template-store.js`; throws an error with `err.code = "DUPLICATE_NAME"` when a conflict is detected, so no direct caller can bypass the uniqueness rule
- Removes the pre-save duplicate check from `handleSave` in `options/options.js` and replaces it with a catch on `DUPLICATE_NAME`, showing the same inline validation error as before
- Adds 4 new tests in `tests/template-store.test.js` covering: new template with duplicate name, update to another template's name, keeping own name on update, and case-insensitivity

## Verification

All new tests pass. The 7 pre-existing `migrateV0toV1` failures are unrelated to this change (they test the input array instead of the returned `templates` property from `.map()`).

Fixes JuliaKalder/TemplateWing#85