### PR TITLE
fix: enforce identity restrictions on nested template resolution

### DIFF
--- a/modules/template-insert.js
+++ b/modules/template-insert.js
@@ -288,12 +288,31 @@ export async function insertTemplateIntoTab(tabId, template) {
   const mode = template.insertMode || INSERT_MODES.APPEND;
   const details = {};
 
+  // Hoist compose details fetch so we can use identityId for both nested
+  // template filtering and later insert-mode operations.
+  let currentIdentityId = null;
+  try {
+    const composeDetails = await messenger.compose.getComposeDetails(tabId);
+    currentIdentityId = composeDetails.identityId || null;
+  } catch (err) {
+    console.warn("TemplateWing: could not fetch compose details for identity filtering", err);
+  }
+
   let resolvedBody = template.body;
   if (template.body && new RegExp(TEMPLATE_INCLUDE_REGEX.source, "i").test(template.body)) {
     try {
       const allTemplates = await getTemplates();
-      const templatesById = new Map(allTemplates.map((t) => [t.id, t]));
-      const templatesByName = new Map(allTemplates.map((t) => [(t.name || "").toLowerCase(), t]));
+      // Filter to only templates that the current identity is allowed to use.
+      // A template with no identities restriction (empty or absent) is always
+      // available; otherwise the current identity must be listed explicitly.
+      const allowedTemplates = allTemplates.filter(
+        (t) =>
+          !t.identities ||
+          t.identities.length === 0 ||
+          (currentIdentityId && t.identities.includes(currentIdentityId))
+      );
+      const templatesById = new Map(allowedTemplates.map((t) => [t.id, t]));
+      const templatesByName = new Map(allowedTemplates.map((t) => [(t.name || "").toLowerCase(), t]));
       const visited = new Set([template.id]);
       resolvedBody = await resolveNestedTemplates(
         template.body,

--- a/modules/template-insert.js
+++ b/modules/template-insert.js
@@ -312,7 +312,9 @@ export async function insertTemplateIntoTab(tabId, template) {
           (currentIdentityId && t.identities.includes(currentIdentityId))
       );
       const templatesById = new Map(allowedTemplates.map((t) => [t.id, t]));
-      const templatesByName = new Map(allowedTemplates.map((t) => [(t.name || "").toLowerCase(), t]));
+      const templatesByName = new Map(
+        allowedTemplates.map((t) => [(t.name || "").toLowerCase(), t])
+      );
       const visited = new Set([template.id]);
       resolvedBody = await resolveNestedTemplates(
         template.body,


### PR DESCRIPTION
## Summary

- `resolveNestedTemplates` was looking up `{{template:Name}}` includes from ALL templates, ignoring their `identities` restrictions — identity-scoped templates could be silently included by any other template.
- In `insertTemplateIntoTab`, the current compose identity is now fetched at the top of the function via `messenger.compose.getComposeDetails(tabId)`.
- `allTemplates` is filtered to `allowedTemplates` before the lookup maps are built: a template passes if its `identities` field is absent/empty (unrestricted) or explicitly lists the current identity.
- The filtered maps are passed to `resolveNestedTemplates`, so nested includes can only resolve templates the active identity is permitted to use.

## Test plan

- [ ] All existing `template-insert.test.js` tests continue to pass (confirmed locally — 7 pre-existing failures in `template-store.test.js` `migrateV0toV1` are unrelated to this change).
- [ ] Manually: compose a message with identity A, insert a template containing `{{template:RestrictedForB}}` where `RestrictedForB.identities = ["identityB"]` — the include should not resolve (warn and leave marker or skip).
- [ ] Verify that templates with no `identities` restriction still resolve normally for any identity.
- [ ] Verify templates explicitly listing the current identity still resolve correctly.

Fixes JuliaKalder/TemplateWing#48