### PR TITLE
refactor: extract groupTemplatesByCategory to template-store.js

### DIFF
--- a/background.js
+++ b/background.js
@@ -5,6 +5,7 @@ import {
   setPrefillTemplate,
   isTemplateAllowedForIdentity,
   getSortedTemplates,
+  groupTemplatesByCategory,
 } from "./modules/template-store.js";
 import { insertTemplateIntoTab } from "./modules/template-insert.js";
 
@@ -77,21 +78,7 @@ async function buildContextMenu(identityId = null) {
     return;
   }
 
-  const categorized = {};
-  const uncategorized = [];
-
-  for (const template of templates) {
-    if (template.category) {
-      if (!categorized[template.category]) {
-        categorized[template.category] = [];
-      }
-      categorized[template.category].push(template);
-    } else {
-      uncategorized.push(template);
-    }
-  }
-
-  const sortedCategories = Object.keys(categorized).sort();
+  const { sortedCategories, byCategory, uncategorized } = groupTemplatesByCategory(templates);
 
   for (const [index, category] of sortedCategories.entries()) {
     const categoryId = getCategoryMenuId(category, index);
@@ -102,7 +89,7 @@ async function buildContextMenu(identityId = null) {
       contexts: ["compose_body"],
     });
 
-    for (const template of categorized[category]) {
+    for (const template of byCategory[category]) {
       messenger.menus.create({
         id: `templatewing-insert-${template.id}`,
         title: template.name,

--- a/modules/template-store.js
+++ b/modules/template-store.js
@@ -219,6 +219,26 @@ export async function consumePrefillTemplate() {
 
 export { PREFILL_KEY };
 
+// ---- Grouping ----
+
+/** Group templates by category, returning sorted category keys and uncategorized templates. */
+export function groupTemplatesByCategory(templates) {
+  const byCategory = {};
+  const uncategorized = [];
+  for (const t of templates) {
+    if (t.category) {
+      (byCategory[t.category] ??= []).push(t);
+    } else {
+      uncategorized.push(t);
+    }
+  }
+  return {
+    sortedCategories: Object.keys(byCategory).sort(),
+    byCategory,
+    uncategorized,
+  };
+}
+
 // ---- Sorting ----
 
 /** Sort templates by category then by name (case-insensitive). */


### PR DESCRIPTION
## Summary
- Add pure `groupTemplatesByCategory(templates)` to `modules/template-store.js`
- Remove inline grouping algorithm from `buildContextMenu` in `background.js`
- Returns `{ sortedCategories, byCategory, uncategorized }`

Fixes JuliaKalder/TemplateWing#123