### PR TITLE
refactor: move import merge strategy from UI to template-store

### DIFF
--- a/modules/template-store.js
+++ b/modules/template-store.js
@@ -231,6 +231,63 @@ export function getSortedTemplates(templates) {
   });
 }
 
+// ---- Import merge strategy ----
+
+/**
+ * Import templates into storage using the specified merge mode.
+ *
+ * @param {Array<Object>} validTemplates - Pre-validated (and pre-sanitized) template objects to import.
+ *   Each template should have tracking fields (id, createdAt, updatedAt, usageCount, lastUsedAt) already stripped.
+ * @param {"append"|"skip"|"replace"} mode - Merge strategy:
+ *   - "append"  — always add as a new template, even if a duplicate name exists
+ *   - "skip"    — leave existing templates unchanged when a name collision is found
+ *   - "replace" — overwrite the existing template when a name collision is found
+ * @returns {Promise<{added: number, skipped: number, replaced: number}>}
+ */
+export async function importTemplates(validTemplates, mode) {
+  const existingTemplates = await getTemplates();
+  const existingByName = new Map(existingTemplates.map((t) => [t.name.toLowerCase(), t]));
+
+  let added = 0;
+  let skipped = 0;
+  let replaced = 0;
+
+  for (const template of validTemplates) {
+    const nameKey = template.name.trim().toLowerCase();
+    const existing = existingByName.get(nameKey);
+
+    if (existing) {
+      if (mode === "skip") {
+        skipped++;
+        continue;
+      }
+      if (mode === "replace") {
+        try {
+          const saved = await saveTemplate({ ...template, id: existing.id });
+          existingByName.set(nameKey, saved);
+          replaced++;
+        } catch (err) {
+          console.error("TemplateWing: import replace failed for", template.name, err);
+          skipped++;
+        }
+        continue;
+      }
+    }
+
+    // mode === "append" or no duplicate
+    try {
+      const saved = await saveTemplate(template);
+      existingByName.set(nameKey, saved);
+      added++;
+    } catch (err) {
+      console.error("TemplateWing: import failed for template", template.name, err);
+      skipped++;
+    }
+  }
+
+  return { added, skipped, replaced };
+}
+
 // Test-only: reset the in-memory cache so tests using a fresh messenger stub
 // are not poisoned by state from earlier tests.
 export function _resetCacheForTests() {

--- a/options/options.js
+++ b/options/options.js
@@ -6,6 +6,7 @@ import {
   getCategories,
   generateId,
   consumePrefillTemplate,
+  importTemplates,
   PREFILL_KEY,
   EXPORT_FORMAT_VERSION,
   INSERT_MODES,
@@ -778,51 +779,18 @@ function sanitizeTemplateBody(html) {
 async function executeImport() {
   if (!pendingImportData) return;
 
-  const { analysis, validTemplates } = pendingImportData;
+  const { validTemplates } = pendingImportData;
   const checkedRadio = document.querySelector('input[name="import-mode"]:checked');
   const mode = checkedRadio ? checkedRadio.value : INSERT_MODES.APPEND;
-  const existingTemplates = await getTemplates();
-  const existingByName = new Map(existingTemplates.map((t) => [t.name.toLowerCase(), t]));
 
-  let added = 0;
-  let skipped = 0;
-  let replaced = 0;
-
-  for (const t of validTemplates) {
-    // Strip internal tracking fields; keep only user-visible template data.
+  // Strip internal tracking fields and sanitize bodies before handing off to the store.
+  const sanitized = validTemplates.map((t) => {
     const { id: _, createdAt: _1, updatedAt: _2, usageCount: _3, lastUsedAt: _4, ...rest } = t;
     rest.body = sanitizeTemplateBody(rest.body);
-    const nameKey = t.name.trim().toLowerCase();
-    const existing = existingByName.get(nameKey);
+    return rest;
+  });
 
-    if (existing) {
-      if (mode === "skip") {
-        skipped++;
-        continue;
-      }
-      if (mode === "replace") {
-        try {
-          const saved = await saveTemplate({ ...rest, id: existing.id });
-          existingByName.set(nameKey, saved);
-          replaced++;
-        } catch (err) {
-          console.error("TemplateWing: import replace failed for", t.name, err);
-          skipped++;
-        }
-        continue;
-      }
-    }
-
-    // mode === "append" or no duplicate
-    try {
-      const saved = await saveTemplate(rest);
-      existingByName.set(nameKey, saved);
-      added++;
-    } catch (err) {
-      console.error("TemplateWing: import failed for template", t.name, err);
-      skipped++;
-    }
-  }
+  const { added, skipped, replaced } = await importTemplates(sanitized, mode);
 
   hideImportDialog();
 


### PR DESCRIPTION
## Summary
- Extract `importTemplates(validTemplates, mode)` into `modules/template-store.js` — it iterates templates, compares by name (case-insensitive), applies the append/skip/replace merge mode, and returns `{ added, skipped, replaced }`
- `executeImport` in `options/options.js` is now a thin UI wrapper: reads the radio value, strips tracking fields, sanitizes bodies (DOM-dependent step that stays in the UI layer), then calls `await importTemplates(sanitized, mode)` and passes counts to `showImportFeedback`
- Domain logic is no longer embedded in the UI layer

Fixes JuliaKalder/TemplateWing#94