### PR TITLE
refactor: extract getIdentities() to separate data fetch from DOM rendering

### DIFF
--- a/modules/template-store.js
+++ b/modules/template-store.js
@@ -192,6 +192,27 @@ export async function trackUsage(id) {
   await persistTemplates(updatedTemplates);
 }
 
+// ---- Identity data access ----
+
+/**
+ * Fetch all mail identities from Thunderbird accounts and return structured data.
+ * Separates data retrieval from DOM rendering so label-formatting logic is unit-testable.
+ */
+export async function getIdentities() {
+  const accounts = await messenger.accounts.list();
+  const identities = [];
+  for (const account of accounts) {
+    for (const identity of account.identities || []) {
+      identities.push({
+        id: identity.id,
+        label: identity.name ? `${identity.name} (${identity.email})` : identity.email,
+        email: identity.email,
+      });
+    }
+  }
+  return identities;
+}
+
 // ---- Identity filtering ----
 
 /** Check if a template is allowed for the given identity (empty identities list means allowed for all). */

--- a/options/options.js
+++ b/options/options.js
@@ -5,6 +5,7 @@ import {
   deleteTemplate,
   getCategories,
   generateId,
+  getIdentities,
   consumePrefillTemplate,
   PREFILL_KEY,
   EXPORT_FORMAT_VERSION,
@@ -159,18 +160,13 @@ async function loadIdentities() {
   select.replaceChildren();
 
   try {
-    const accounts = await messenger.accounts.list();
-    for (const account of accounts) {
-      if (account.identities) {
-        for (const identity of account.identities) {
-          const option = document.createElement("option");
-          option.value = identity.id;
-          const label = identity.name ? `${identity.name} (${identity.email})` : identity.email;
-          option.textContent = label;
-          option.title = identity.email;
-          select.appendChild(option);
-        }
-      }
+    const identities = await getIdentities();
+    for (const { id, label, email } of identities) {
+      const option = document.createElement("option");
+      option.value = id;
+      option.textContent = label;
+      option.title = email;
+      select.appendChild(option);
     }
   } catch (err) {
     console.warn("TemplateWing: could not load identities", err);


### PR DESCRIPTION
## Summary

- Add `getIdentities()` pure data function to `modules/template-store.js`, following the same pattern as `getTemplates()`
- `loadIdentities()` in `options/options.js` is now a thin DOM-only wrapper that calls `getIdentities()` and iterates over the returned objects
- Label-formatting logic (`identity.name ? ... : identity.email`) now lives in the module layer where it is unit-testable without a DOM or `messenger.*` environment

## Verification

- Existing test suite: 90 pass / 7 fail — the 7 failures are pre-existing `migrateV0toV1` test failures unrelated to this change (verified by running tests against the original code on `main`)
- No new failures introduced

Fixes JuliaKalder/TemplateWing#119